### PR TITLE
Tests for overeager autolinking in raw HTML in tables

### DIFF
--- a/test/spec.js
+++ b/test/spec.js
@@ -6,6 +6,18 @@ export const spec = [
       '<table>\n<thead>\n<tr>\n<th>foo</th>\n<th>bar</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>baz</td>\n<td>bim</td>\n</tr>\n</tbody>\n</table>\n'
   },
   {
+    category: 'Tables - HTML',
+    input: '| foo | bar |\n| --- | --- |\n| baz | <a href="http://www.example.com">www.example.com</a> |\n',
+    output:
+      '<table>\n<thead>\n<tr>\n<th>foo</th>\n<th>bar</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>baz</td>\n<td><a href="http://www.example.com">www.example.com</a></td>\n</tr>\n</tbody>\n</table>\n'
+  },
+  {
+    category: 'Tables - Autolinks',
+    input: '| foo | bar |\n| --- | --- |\n| baz | www.example.com |\n',
+    output:
+      '<table>\n<thead>\n<tr>\n<th>foo</th>\n<th>bar</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>baz</td>\n<td><a href="http://www.example.com">www.example.com</a></td>\n</tr>\n</tbody>\n</table>\n'
+  },
+  {
     category: 'Tables',
     input: '| abc | defghi |\n:-: | -----------:\nbar | baz\n',
     output:

--- a/test/spec.js
+++ b/test/spec.js
@@ -19,9 +19,15 @@ export const spec = [
   },
   {
     category: 'HTML - Autolinks',
-    input: '<a href="http://www.example.com">http://www.example.com</a>\n',
+    input: '/media/oembed?url=https://www.example.com/%3Ffoo=bar\n',
     output:
-      '<p><a href="http://www.example.com">www.example.com</a></p>\n'
+      '<p>/media/oembed?url=https://www.example.com/%3Ffoo=bar</p>\n'
+  },
+  {
+    category: 'HTML - Autolinks',
+    input: '/media/oembed?url=https%3a//www.example.com/%3Ffoo=bar\n',
+    output:
+      '<p>/media/oembed?url=https%3a//www.example.com/%3Ffoo=bar</p>\n'
   },
   {
     category: 'HTML - Autolinks',

--- a/test/spec.js
+++ b/test/spec.js
@@ -15,7 +15,7 @@ export const spec = [
     category: 'Tables - HTML - Autolinks',
     input: '| foo | bar |\n| --- | --- |\n| baz | <a href="http://www.example.com">http://www.example.com</a> |\n',
     output:
-      '<table>\n<thead>\n<tr>\n<th>foo</th>\n<th>bar</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>baz</td>\n<td><a href="http://www.example.com">www.example.com</a></td>\n</tr>\n</tbody>\n</table>\n'
+      '<table>\n<thead>\n<tr>\n<th>foo</th>\n<th>bar</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>baz</td>\n<td><a href="http://www.example.com">http://www.example.com</a></td>\n</tr>\n</tbody>\n</table>\n'
   },
   {
     category: 'HTML - Autolinks',

--- a/test/spec.js
+++ b/test/spec.js
@@ -21,7 +21,13 @@ export const spec = [
     category: 'HTML - Autolinks',
     input: '<a href="http://www.example.com">http://www.example.com</a>\n',
     output:
-      '<a href="http://www.example.com">www.example.com</a>\n'
+      '<p><a href="http://www.example.com">www.example.com</a></p>\n'
+  },
+  {
+    category: 'HTML - Autolinks',
+    input: '<a href="http://www.example.com">www.example.com</a>\n',
+    output:
+      '<p><a href="http://www.example.com">www.example.com</a></p>\n'
   },
   {
     category: 'Tables - Autolinks',

--- a/test/spec.js
+++ b/test/spec.js
@@ -18,6 +18,12 @@ export const spec = [
       '<table>\n<thead>\n<tr>\n<th>foo</th>\n<th>bar</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>baz</td>\n<td><a href="http://www.example.com">www.example.com</a></td>\n</tr>\n</tbody>\n</table>\n'
   },
   {
+    category: 'HTML - Autolinks',
+    input: '<a href="http://www.example.com">http://www.example.com</a>\n',
+    output:
+      '<a href="http://www.example.com">www.example.com</a>\n'
+  },
+  {
     category: 'Tables - Autolinks',
     input: '| foo | bar |\n| --- | --- |\n| baz | www.example.com |\n',
     output:

--- a/test/spec.js
+++ b/test/spec.js
@@ -12,6 +12,12 @@ export const spec = [
       '<table>\n<thead>\n<tr>\n<th>foo</th>\n<th>bar</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>baz</td>\n<td><a href="http://www.example.com">www.example.com</a></td>\n</tr>\n</tbody>\n</table>\n'
   },
   {
+    category: 'Tables - HTML - Autolinks',
+    input: '| foo | bar |\n| --- | --- |\n| baz | <a href="http://www.example.com">http://www.example.com</a> |\n',
+    output:
+      '<table>\n<thead>\n<tr>\n<th>foo</th>\n<th>bar</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>baz</td>\n<td><a href="http://www.example.com">www.example.com</a></td>\n</tr>\n</tbody>\n</table>\n'
+  },
+  {
     category: 'Tables - Autolinks',
     input: '| foo | bar |\n| --- | --- |\n| baz | www.example.com |\n',
     output:


### PR DESCRIPTION
@tripodsan found an issue (regression) with regards to autolinking of raw HTML. The test shows that a link starting with http:// will be turned into an autolink, even when the parser should be in a raw HTML parsing mode


```
not ok 3 Tables - HTML - Autolinks (2)
  ---
    operator: deepEqual
    expected: |-
      '<table>\n<thead>\n<tr>\n<th>foo</th>\n<th>bar</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>baz</td>\n<td><a href="http://www.example.com">www.example.com</a></td>\n</tr>\n</tbody>\n</table>\n'
    actual: |-
      '<table>\n<thead>\n<tr>\n<th>foo</th>\n<th>bar</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>baz</td>\n<td><a href="http://www.example.com"><a href="http://www.example.com">http://www.example.com</a></a></td>\n</tr>\n</tbody>\n</table>\n'
    stack: |-
      Error: Tables - HTML - Autolinks (2)
          at Test.assert [as _assert] (/Users/lars/Code/micromark-extension-gfm/node_modules/tape/lib/test.js:311:54)
```

Originally found in the context of tables, but it seems to be generalizable to all autolinks.